### PR TITLE
Configure Ukrainian locale and Kyiv time zone

### DIFF
--- a/biomarket/settings.py
+++ b/biomarket/settings.py
@@ -82,8 +82,8 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # --- I18N ---
-LANGUAGE_CODE = "en-us"
-TIME_ZONE = "UTC"
+LANGUAGE_CODE = "uk"
+TIME_ZONE = "Europe/Kyiv"
 USE_I18N = True
 USE_TZ = True
 


### PR DESCRIPTION
## Summary
- set Django `LANGUAGE_CODE` to `uk`
- set default `TIME_ZONE` to `Europe/Kyiv`

## Testing
- `python manage.py test`
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','biomarket.settings')
django.setup()
from django.utils import timezone, translation, formats
from django.conf import settings
print('LANGUAGE_CODE', settings.LANGUAGE_CODE)
print('TIME_ZONE', settings.TIME_ZONE)
now = timezone.now()
print('UTC now', now)
local = timezone.localtime(now)
print('Local time', local)
translation.activate('uk')
print('Formatted time', formats.date_format(local, 'DATETIME_FORMAT'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c5815b9be0832cb69f1b7c1f3972d9