### PR TITLE
Fix product fixtures to use title and availability

### DIFF
--- a/biomarket/fixtures/sample_products.json
+++ b/biomarket/fixtures/sample_products.json
@@ -13,7 +13,7 @@
     "model": "shop.product",
     "pk": 1,
     "fields": {
-      "name": "Яблука органічні",
+      "title": "Яблука органічні",
       "slug": "yabluka-organichni",
       "description": "Свіжі, хрумкі, солодкі.",
       "price": "55.00",
@@ -25,7 +25,7 @@
     "model": "shop.product",
     "pk": 2,
     "fields": {
-      "name": "Груші фермерські",
+      "title": "Груші фермерські",
       "slug": "hrushi-fermerski",
       "description": "Ароматні й соковиті.",
       "price": "68.00",
@@ -37,7 +37,7 @@
     "model": "shop.product",
     "pk": 3,
     "fields": {
-      "name": "Морква",
+      "title": "Морква",
       "slug": "morkva",
       "description": "Солодка молода морква.",
       "price": "29.00",

--- a/shop/fixtures.json
+++ b/shop/fixtures.json
@@ -24,8 +24,9 @@
       "slug": "med-lypovyi-500",
       "description": "Ароматний натуральний мед з липи.",
       "price": "220.00",
-      "stock": 50,
-      "is_active": true
+      "available": true,
+      "created": "2024-01-01T00:00:00Z",
+      "updated": "2024-01-01T00:00:00Z"
     }
   },
   {


### PR DESCRIPTION
## Summary
- remove obsolete `stock` and `is_active` fields from fixtures and add `available` with timestamps
- update sample products to use `title` field

## Testing
- `python manage.py migrate`
- `python manage.py loaddata shop/fixtures.json`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c584a98540832c8b20d8ff039adb66