### PR TITLE
Move inline styles to external stylesheet

### DIFF
--- a/biomarket/static/style.css
+++ b/biomarket/static/style.css
@@ -1,1 +1,23 @@
-/* add styles later */
+body{
+  font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;
+  margin:0;
+  line-height:1.6;
+}
+
+.wrap{
+  max-width:860px;
+  margin:4rem auto;
+  padding:0 1rem;
+}
+
+h1{
+  margin:0 0 .5rem;
+}
+
+.card{
+  border:1px solid #eee;
+  border-radius:14px;
+  padding:1.25rem;
+  background:#fff;
+}
+

--- a/biomarket/templates/index.html
+++ b/biomarket/templates/index.html
@@ -5,12 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Biomarket</title>
     <link rel="stylesheet" href="/static/style.css">
-    <style>
-      body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;line-height:1.6}
-      .wrap{max-width:860px;margin:4rem auto;padding:0 1rem}
-      h1{margin:0 0 .5rem}
-      .card{border:1px solid #eee;border-radius:14px;padding:1.25rem;background:#fff}
-    </style>
   </head>
   <body>
     <div class="wrap">


### PR DESCRIPTION
## Summary
- move home page styles from inline `<style>` block to `static/style.css`
- remove inline style tag and keep link to shared stylesheet

## Testing
- `pip install -r requirements.txt` (fails: Could not connect to proxy / no matching distribution)
- `python manage.py test` (fails: ModuleNotFoundError: No module named 'django')


------
https://chatgpt.com/codex/tasks/task_e_68c6b904ad78832c9ae84e435811a2e2