### PR TITLE
Add base template with navigation

### DIFF
--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -1,0 +1,28 @@
+{% load static %}
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Biomarket{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'style.css' %}">
+  </head>
+  <body>
+    <header>
+      <nav class="wrap">
+        <a href="{% url 'home' %}">Головна</a>
+        <a href="/catalog/">Каталог</a>
+        <a href="/about/">Про нас</a>
+        <a href="/contacts/">Контакти</a>
+      </nav>
+    </header>
+    <main class="wrap">
+      {% block content %}{% endblock %}
+    </main>
+    <footer>
+      <div class="wrap">
+        <p>&copy; {% now 'Y' %} Biomarket</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/biomarket/templates/index.html
+++ b/biomarket/templates/index.html
@@ -1,17 +1,8 @@
-<!doctype html>
-<html lang="uk">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Biomarket</title>
-    <link rel="stylesheet" href="/static/style.css">
-  </head>
-  <body>
-    <div class="wrap">
-      <div class="card">
-        <h1>Biomarket працює ✅</h1>
-        <p>Це стартова сторінка. Далі будемо додавати каталог товарів, кошик і оплату.</p>
-      </div>
-    </div>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="card">
+    <h1>Biomarket працює ✅</h1>
+    <p>Це стартова сторінка. Далі будемо додавати каталог товарів, кошик і оплату.</p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Create `base.html` template with header, navigation menu, and footer
- Update index page to extend the base template

## Testing
- `python -m pytest`
- `./.venv/bin/python biomarket/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5d87d34832ca3a2ab486667125e