### PR TITLE
Add about and contact pages with navigation

### DIFF
--- a/biomarket/biomarket/urls.py
+++ b/biomarket/biomarket/urls.py
@@ -3,5 +3,7 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="home"),
+    path("about/", TemplateView.as_view(template_name="about.html"), name="about"),
+    path("contacts/", TemplateView.as_view(template_name="contact.html"), name="contacts"),
     path("products/", include("products.urls")),
 ]

--- a/biomarket/templates/about.html
+++ b/biomarket/templates/about.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block title %}Про нас - Biomarket{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <h1>Про нас</h1>
+    <p>Biomarket — онлайн-магазин натуральних продуктів для здорового життя. Ми пропонуємо органічні продукти, косметику та товари для дому.</p>
+  </div>
+{% endblock %}

--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -12,9 +12,9 @@
     <header>
       <nav class="wrap">
         <a href="{% url 'home' %}">Головна</a>
-        <a href="/catalog/">Каталог</a>
-        <a href="/about/">Про нас</a>
-        <a href="/contacts/">Контакти</a>
+        <a href="{% url 'product_list' %}">Каталог</a>
+        <a href="{% url 'about' %}">Про нас</a>
+        <a href="{% url 'contacts' %}">Контакти</a>
       </nav>
     </header>
     <main class="wrap">

--- a/biomarket/templates/contact.html
+++ b/biomarket/templates/contact.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Контакти - Biomarket{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <h1>Контакти</h1>
+    <p>Маєте запитання? Звертайтесь:</p>
+    <ul>
+      <li>Телефон: <a href="tel:+380123456789">+380 12 345 6789</a></li>
+      <li>Email: <a href="mailto:info@biomarket.com">info@biomarket.com</a></li>
+      <li>Адреса: м. Київ, вул. Прикладна, 1</li>
+    </ul>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add static about and contacts pages with Ukrainian content
- expose `/about/` and `/contacts/` routes and update nav links

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c7c12c23d4832c98e86f3fc0923c8a