### PR TITLE
Add product slug and detail view

### DIFF
--- a/biomarket/products/migrations/0002_product_slug.py
+++ b/biomarket/products/migrations/0002_product_slug.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("products", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="product",
+            name="slug",
+            field=models.SlugField(default="temp-slug", unique=True),
+            preserve_default=False,
+        ),
+    ]

--- a/biomarket/products/models.py
+++ b/biomarket/products/models.py
@@ -6,6 +6,7 @@ class Product(models.Model):
     description = models.TextField(blank=True)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     image = models.ImageField(upload_to="products/", blank=True)
+    slug = models.SlugField(unique=True)
 
     def __str__(self) -> str:
         return self.name

--- a/biomarket/products/urls.py
+++ b/biomarket/products/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.product_list, name='product_list'),
+    path('<slug:slug>/', views.product_detail, name='product_detail'),
 ]

--- a/biomarket/products/views.py
+++ b/biomarket/products/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from .models import Product
 
@@ -6,3 +6,8 @@ from .models import Product
 def product_list(request):
     products = Product.objects.all()
     return render(request, "products/list.html", {"products": products})
+
+
+def product_detail(request, slug):
+    product = get_object_or_404(Product, slug=slug)
+    return render(request, "products/detail.html", {"product": product})

--- a/biomarket/templates/products/detail.html
+++ b/biomarket/templates/products/detail.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ product.name }}{% endblock %}
+
+{% block content %}
+  <h1>{{ product.name }}</h1>
+  {% if product.image %}
+    <img src="{{ product.image.url }}" alt="{{ product.name }}" class="img-fluid mb-3">
+  {% endif %}
+  <p>{{ product.description }}</p>
+  <p><strong>{{ product.price }} грн</strong></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add unique slug to products
- implement product detail view and template

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django)*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c7cc8da658832c886feb3e81721030