### PR TITLE
Make product list items link to detail pages

### DIFF
--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -9,10 +9,14 @@
       <div class="col-md-4 mb-4">
         <div class="card h-100">
           {% if product.image %}
-            <img src="{{ product.image.url }}" class="card-img-top" alt="{{ product.name }}">
+            <a href="{% url 'product_detail' product.slug %}">
+              <img src="{{ product.image.url }}" class="card-img-top" alt="{{ product.name }}">
+            </a>
           {% endif %}
           <div class="card-body">
-            <h5 class="card-title">{{ product.name }}</h5>
+            <h5 class="card-title">
+              <a href="{% url 'product_detail' product.slug %}">{{ product.name }}</a>
+            </h5>
             <p class="card-text">{{ product.description }}</p>
           </div>
           <div class="card-footer">


### PR DESCRIPTION
## Summary
- Link product images and names to their detail pages for easier navigation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.2,>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c7da619ff0832c8b7556a336958662