### PR TITLE
Auto-generate product slugs

### DIFF
--- a/biomarket/products/admin.py
+++ b/biomarket/products/admin.py
@@ -6,3 +6,4 @@ from .models import Product
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
     list_display = ("name", "price")
+    prepopulated_fields = {"slug": ("name",)}

--- a/biomarket/products/models.py
+++ b/biomarket/products/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.text import slugify
 
 
 class Product(models.Model):
@@ -7,6 +8,11 @@ class Product(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     image = models.ImageField(upload_to="products/", blank=True)
     slug = models.SlugField(unique=True)
+
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = slugify(self.name)
+        super().save(*args, **kwargs)
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Summary
- Populate Product.slug via slugify when missing
- Pre-populate slug from name in Django admin

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.2,>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ddd67238832cb0ffe3b07a4f89de