### PR TITLE
Configure persistent database and migrations

### DIFF
--- a/biomarket/biomarket/settings.py
+++ b/biomarket/biomarket/settings.py
@@ -51,10 +51,11 @@ TEMPLATES = [
 WSGI_APPLICATION = "biomarket.wsgi.application"
 ASGI_APPLICATION = "biomarket.asgi.application"
 
+DB_PATH = os.getenv("DJANGO_DB_PATH", BASE_DIR / "db.sqlite3")
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": DB_PATH,
     }
 }
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: biomarket
+    env: python
+    buildCommand: cd biomarket && pip install -r requirements.txt
+    startCommand: cd biomarket && python manage.py migrate && gunicorn biomarket.wsgi
+    envVars:
+      - key: DJANGO_DB_PATH
+        value: /var/data/db.sqlite3
+    disk:
+      name: data
+      mountPath: /var/data


### PR DESCRIPTION
## Summary
- run migrations automatically on deploy via render.yaml
- allow overriding DB file location for persistent storage

## Testing
- `pip install -r biomarket/requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.2,>=5.0)*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c7ec50cf68832c9925b1fc78b670c1