### PR TITLE
Replace custom navigation with Bootstrap navbar

### DIFF
--- a/biomarket/static/style.css
+++ b/biomarket/static/style.css
@@ -26,33 +26,6 @@ h1 {
   margin: 0 0 0.5rem;
 }
 
-/* Header and navigation */
-header {
-  background: var(--color-primary);
-  color: var(--color-light);
-}
-
-header nav {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-  justify-content: center;
-  padding: 1rem;
-}
-
-header nav a {
-  color: var(--color-light);
-  text-decoration: none;
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-}
-
-header nav a:hover,
-header nav a:focus {
-  background: var(--color-accent);
-  color: var(--color-light);
-}
-
 /* Footer */
 footer {
   background: var(--color-primary);
@@ -80,11 +53,6 @@ main.wrap {
 @media (max-width: 600px) {
   .wrap {
     margin: 2rem auto;
-  }
-
-  header nav {
-    flex-direction: column;
-    align-items: center;
   }
 }
 

--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -10,11 +10,29 @@
   </head>
   <body>
     <header>
-      <nav class="wrap">
-        <a href="{% url 'home' %}">Головна</a>
-        <a href="{% url 'product_list' %}">Каталог</a>
-        <a href="{% url 'about' %}">Про нас</a>
-        <a href="{% url 'contacts' %}">Контакти</a>
+      <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+          <a class="navbar-brand" href="{% url 'home' %}">Biomarket</a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'home' %}">Головна</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'product_list' %}">Каталог</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'about' %}">Про нас</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'contacts' %}">Контакти</a>
+              </li>
+            </ul>
+          </div>
+        </div>
       </nav>
     </header>
     <main class="wrap">


### PR DESCRIPTION
## Summary
- Replace custom nav markup with Bootstrap navbar, including brand and mobile toggler
- Remove bespoke navigation CSS to rely on Bootstrap's styling

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.2,>=5.0 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c82639a89c832c8495ccca1e839e33