### PR TITLE
Configure SEO metadata and sitemap

### DIFF
--- a/biomarket/biomarket/settings.py
+++ b/biomarket/biomarket/settings.py
@@ -16,6 +16,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
     "products",
 ]
 

--- a/biomarket/biomarket/sitemaps.py
+++ b/biomarket/biomarket/sitemaps.py
@@ -1,0 +1,26 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from products.models import Product
+
+
+class StaticViewSitemap(Sitemap):
+    priority = 0.9
+    changefreq = "weekly"
+
+    def items(self):
+        return ["home", "about", "contacts"]
+
+    def location(self, item):
+        return reverse(item)
+
+
+class ProductSitemap(Sitemap):
+    changefreq = "weekly"
+    priority = 0.8
+
+    def items(self):
+        return Product.objects.all()
+
+    def location(self, obj):
+        return obj.get_absolute_url()

--- a/biomarket/biomarket/urls.py
+++ b/biomarket/biomarket/urls.py
@@ -1,9 +1,57 @@
+from django.contrib.sitemaps.views import sitemap
 from django.urls import path, include
 from django.views.generic import TemplateView
 
+from .sitemaps import ProductSitemap, StaticViewSitemap
+
+sitemaps = {
+    "static": StaticViewSitemap,
+    "products": ProductSitemap,
+}
+
 urlpatterns = [
-    path("", TemplateView.as_view(template_name="index.html"), name="home"),
-    path("about/", TemplateView.as_view(template_name="about.html"), name="about"),
-    path("contacts/", TemplateView.as_view(template_name="contact.html"), name="contacts"),
+    path(
+        "",
+        TemplateView.as_view(
+            template_name="index.html",
+            extra_context={
+                "meta_title": "Biomarket — органічні продукти та еко товари",
+                "description": "Biomarket пропонує широкий вибір органічних та еко товарів для здорового життя.",
+                "keywords": "Biomarket, органічні продукти, еко товари, здорова їжа",
+                "og_type": "website",
+                "twitter_card": "summary",
+            },
+        ),
+        name="home",
+    ),
+    path(
+        "about/",
+        TemplateView.as_view(
+            template_name="about.html",
+            extra_context={
+                "meta_title": "Про Biomarket",
+                "description": "Дізнайтеся більше про місію Biomarket та наш підхід до відбору еко-продуктів.",
+                "keywords": "Biomarket, про компанію, місія, еко продукти",
+                "og_type": "website",
+                "twitter_card": "summary",
+            },
+        ),
+        name="about",
+    ),
+    path(
+        "contacts/",
+        TemplateView.as_view(
+            template_name="contact.html",
+            extra_context={
+                "meta_title": "Контакти Biomarket",
+                "description": "Зв'яжіться з Biomarket: телефони, email та адреса для замовлень органічних продуктів.",
+                "keywords": "Biomarket контакти, служба підтримки, органічні продукти",
+                "og_type": "website",
+                "twitter_card": "summary",
+            },
+        ),
+        name="contacts",
+    ),
     path("products/", include("products.urls")),
+    path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="sitemap"),
 ]

--- a/biomarket/products/models.py
+++ b/biomarket/products/models.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 
 
@@ -9,10 +12,30 @@ class Product(models.Model):
     image = models.ImageField(upload_to="products/", blank=True)
     slug = models.SlugField(unique=True)
 
+    def _generate_unique_slug(self, base_slug: Optional[str] = None) -> str:
+        slug = base_slug or slugify(self.name)
+        if not slug:
+            slug = "product"
+        unique_slug = slug
+        counter = 1
+        queryset = Product.objects.all()
+        if self.pk:
+            queryset = queryset.exclude(pk=self.pk)
+        while queryset.filter(slug=unique_slug).exists():
+            unique_slug = f"{slug}-{counter}"
+            counter += 1
+        return unique_slug
+
     def save(self, *args, **kwargs):
         if not self.slug:
-            self.slug = slugify(self.name)
+            self.slug = self._generate_unique_slug()
+        else:
+            base_slug = slugify(self.slug) or slugify(self.name)
+            self.slug = self._generate_unique_slug(base_slug)
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:
         return self.name
+
+    def get_absolute_url(self):
+        return reverse("product_detail", args=[self.slug])

--- a/biomarket/products/views.py
+++ b/biomarket/products/views.py
@@ -1,13 +1,40 @@
 from django.shortcuts import get_object_or_404, render
+from django.utils.text import Truncator
 
 from .models import Product
 
 
 def product_list(request):
     products = Product.objects.all()
-    return render(request, "products/list.html", {"products": products})
+    description = (
+        "Каталог Biomarket: натуральні та органічні товари для здорового життя, "
+        "доступні за вигідними цінами."
+    )
+    context = {
+        "products": products,
+        "meta_title": "Каталог товарів Biomarket",
+        "description": description,
+        "keywords": "Biomarket, каталог товарів, органічні продукти, еко продукти",
+        "og_type": "website",
+        "twitter_card": "summary",
+    }
+    return render(request, "products/list.html", context)
 
 
 def product_detail(request, slug):
     product = get_object_or_404(Product, slug=slug)
-    return render(request, "products/detail.html", {"product": product})
+    description_source = product.description or f"Купити {product.name} в Biomarket"
+    description = Truncator(description_source).chars(160)
+    meta_image = None
+    if product.image:
+        meta_image = request.build_absolute_uri(product.image.url)
+    context = {
+        "product": product,
+        "meta_title": f"{product.name} — Biomarket",
+        "description": description,
+        "keywords": f"{product.name}, Biomarket, органічні товари",
+        "og_type": "product",
+        "meta_image": meta_image,
+        "twitter_card": "summary_large_image" if meta_image else "summary",
+    }
+    return render(request, "products/detail.html", context)

--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -4,7 +4,30 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Biomarket{% endblock %}</title>
+    <title>{% block title %}{{ meta_title|default:"Biomarket" }}{% endblock %}</title>
+    {% block meta %}
+      {% with default_title="Biomarket" default_description="Biomarket — інтернет-магазин органічних продуктів та товарів для здорового способу життя." default_keywords="Biomarket, органічні продукти, здорова їжа, еко товари" %}
+        <meta name="description" content="{{ description|default:default_description }}">
+        <meta name="keywords" content="{{ keywords|default:default_keywords }}">
+        <meta name="author" content="Biomarket">
+        <meta property="og:site_name" content="Biomarket">
+        <meta property="og:title" content="{{ meta_title|default:default_title }}">
+        <meta property="og:description" content="{{ description|default:default_description }}">
+        <meta property="og:type" content="{{ og_type|default:'website' }}">
+        {% with request.build_absolute_uri as absolute_url %}
+          <meta property="og:url" content="{{ og_url|default:absolute_url }}">
+        {% endwith %}
+        {% if meta_image %}
+          <meta property="og:image" content="{{ meta_image }}">
+        {% endif %}
+        <meta name="twitter:card" content="{{ twitter_card|default:'summary_large_image' }}">
+        <meta name="twitter:title" content="{{ meta_title|default:default_title }}">
+        <meta name="twitter:description" content="{{ description|default:default_description }}">
+        {% if meta_image %}
+          <meta name="twitter:image" content="{{ meta_image }}">
+        {% endif %}
+      {% endwith %}
+    {% endblock %}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'style.css' %}">
   </head>

--- a/biomarket/templates/products/detail.html
+++ b/biomarket/templates/products/detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ product.name }}{% endblock %}
+{% block title %}{{ meta_title|default:product.name }}{% endblock %}
 
 {% block content %}
   <h1>{{ product.name }}</h1>

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Список товарів{% endblock %}
+{% block title %}{{ meta_title|default:"Список товарів" }}{% endblock %}
 
 {% block content %}
   <h1>Список товарів</h1>


### PR DESCRIPTION
## Summary
- add reusable metadata block with description, keywords, Open Graph and Twitter tags in the base template
- provide SEO context data for catalog and product detail views as well as static pages
- configure Django sitemaps and harden product slug generation with canonical URLs

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c83bd04bfc832c96b893d5d73ae977