### PR TITLE
Add stock field and availability display

### DIFF
--- a/biomarket/products/admin.py
+++ b/biomarket/products/admin.py
@@ -5,5 +5,5 @@ from .models import Product
 
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
-    list_display = ("name", "price")
+    list_display = ("name", "price", "stock")
     prepopulated_fields = {"slug": ("name",)}

--- a/biomarket/products/migrations/0003_product_stock.py
+++ b/biomarket/products/migrations/0003_product_stock.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("products", "0002_product_slug"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="product",
+            name="stock",
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/biomarket/products/models.py
+++ b/biomarket/products/models.py
@@ -11,6 +11,7 @@ class Product(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     image = models.ImageField(upload_to="products/", blank=True)
     slug = models.SlugField(unique=True)
+    stock = models.PositiveIntegerField(default=0)
 
     def _generate_unique_slug(self, base_slug: Optional[str] = None) -> str:
         slug = base_slug or slugify(self.name)

--- a/biomarket/templates/products/detail.html
+++ b/biomarket/templates/products/detail.html
@@ -9,4 +9,7 @@
   {% endif %}
   <p>{{ product.description }}</p>
   <p><strong>{{ product.price }} грн</strong></p>
+  <p class="{% if product.stock > 0 %}text-success{% else %}text-danger{% endif %}">
+    {% if product.stock > 0 %}в наявності{% else %}немає{% endif %}
+  </p>
 {% endblock %}

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -43,8 +43,11 @@
             </h5>
             <p class="card-text">{{ product.description }}</p>
           </div>
-          <div class="card-footer">
+          <div class="card-footer d-flex justify-content-between align-items-center">
             <strong>{{ product.price }} грн</strong>
+            <span class="{% if product.stock > 0 %}text-success{% else %}text-danger{% endif %}">
+              {% if product.stock > 0 %}в наявності{% else %}немає{% endif %}
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a stock field to the Product model with a default of zero and include the matching migration
- surface the stock value in the product admin list
- show an availability message based on stock across the product list and detail templates

## Testing
- python manage.py makemigrations *(fails: ModuleNotFoundError: No module named 'django')*
- python manage.py migrate *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c84c98c528832c980fc3610192d49b