### PR TITLE
Add pagination to product catalog

### DIFF
--- a/biomarket/products/views.py
+++ b/biomarket/products/views.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.utils.text import Truncator
 
@@ -21,15 +22,30 @@ def product_list(request):
         "Каталог Biomarket: натуральні та органічні товари для здорового життя, "
         "доступні за вигідними цінами."
     )
+    paginator = Paginator(products, 12)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+
+    meta_title = "Каталог товарів Biomarket"
+    if page_obj.number > 1:
+        meta_title = f"Каталог товарів Biomarket – сторінка {page_obj.number}"
+
+    query_params = request.GET.copy()
+    if "page" in query_params:
+        query_params.pop("page")
+    preserved_query = query_params.urlencode()
+
     context = {
-        "products": products,
+        "products": page_obj.object_list,
         "q": query,
         "current_sort": sort if sort in {"price", "name"} else "",
-        "meta_title": "Каталог товарів Biomarket",
+        "meta_title": meta_title,
         "description": description,
         "keywords": "Biomarket, каталог товарів, органічні продукти, еко продукти",
         "og_type": "website",
         "twitter_card": "summary",
+        "page_obj": page_obj,
+        "preserved_query": preserved_query,
     }
     return render(request, "products/list.html", context)
 

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -29,7 +29,7 @@
     </div>
   </form>
   <div class="row">
-    {% for product in products %}
+    {% for product in page_obj %}
       <div class="col-md-4 mb-4">
         <div class="card h-100">
           {% if product.image %}
@@ -55,4 +55,39 @@
       <p>Немає товарів.</p>
     {% endfor %}
   </div>
+  {% if page_obj.has_other_pages %}
+    <nav aria-label="Навігація по каталогу" class="mt-4">
+      <ul class="pagination justify-content-center">
+        <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+          {% if page_obj.has_previous %}
+            <a class="page-link" href="?{% if preserved_query %}{{ preserved_query }}&amp;{% endif %}page={{ page_obj.previous_page_number }}" aria-label="Попередня">
+              <span aria-hidden="true">&laquo;</span>
+              <span class="visually-hidden">Попередня</span>
+            </a>
+          {% else %}
+            <span class="page-link" aria-label="Попередня">
+              <span aria-hidden="true">&laquo;</span>
+              <span class="visually-hidden">Попередня</span>
+            </span>
+          {% endif %}
+        </li>
+        <li class="page-item disabled">
+          <span class="page-link">Сторінка {{ page_obj.number }} з {{ page_obj.paginator.num_pages }}</span>
+        </li>
+        <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+          {% if page_obj.has_next %}
+            <a class="page-link" href="?{% if preserved_query %}{{ preserved_query }}&amp;{% endif %}page={{ page_obj.next_page_number }}" aria-label="Наступна">
+              <span aria-hidden="true">&raquo;</span>
+              <span class="visually-hidden">Наступна</span>
+            </a>
+          {% else %}
+            <span class="page-link" aria-label="Наступна">
+              <span aria-hidden="true">&raquo;</span>
+              <span class="visually-hidden">Наступна</span>
+            </span>
+          {% endif %}
+        </li>
+      </ul>
+    </nav>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- paginate the product list view and adjust metadata for numbered pages
- preserve search and sort query parameters while providing Bootstrap navigation controls

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c9108fe0e4832cbb83e7c8b037f4b6