### PR TITLE
Improve product list cards with cart integration

### DIFF
--- a/biomarket/cart/urls.py
+++ b/biomarket/cart/urls.py
@@ -6,4 +6,5 @@ app_name = "cart"
 
 urlpatterns = [
     path("", views.cart_home, name="home"),
+    path("add/<slug:slug>/", views.add_to_cart, name="add"),
 ]

--- a/biomarket/cart/views.py
+++ b/biomarket/cart/views.py
@@ -1,6 +1,53 @@
 from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+
+from products.models import Product
+
+from .models import Cart, CartItem
 
 
 def cart_home(request: HttpRequest) -> HttpResponse:
     """Display a minimal placeholder cart page."""
     return HttpResponse("Cart is empty", content_type="text/plain")
+
+
+def _get_or_create_cart(request: HttpRequest) -> Cart:
+    """Return a cart linked to the current session or create a new one."""
+
+    cart_id = request.session.get("cart_id")
+    cart = Cart.objects.filter(pk=cart_id).first() if cart_id else None
+
+    if request.user.is_authenticated:
+        if cart and cart.user_id not in (None, request.user.id):
+            cart = None
+        if cart is None:
+            cart, _created = Cart.objects.get_or_create(user=request.user)
+        elif cart.user_id is None:
+            cart.user = request.user
+            cart.save(update_fields=["user"])
+    else:
+        if cart is None:
+            cart = Cart.objects.create()
+
+    request.session["cart_id"] = cart.pk
+    return cart
+
+
+def add_to_cart(request: HttpRequest, slug: str) -> HttpResponse:
+    """Add the selected product to the active cart and redirect back."""
+
+    product = get_object_or_404(Product, slug=slug)
+
+    if product.stock <= 0:
+        return redirect(request.GET.get("next") or product.get_absolute_url())
+
+    cart = _get_or_create_cart(request)
+    cart_item, created = CartItem.objects.get_or_create(cart=cart, product=product)
+
+    if not created:
+        cart_item.quantity += 1
+        cart_item.save(update_fields=["quantity"])
+
+    redirect_url = request.GET.get("next") or reverse("cart:home")
+    return redirect(redirect_url)

--- a/biomarket/static/style.css
+++ b/biomarket/static/style.css
@@ -47,6 +47,51 @@ main.wrap {
   border-radius: 14px;
   padding: 1.25rem;
   background: #fff;
+  box-shadow: 0 12px 30px rgba(33, 37, 41, 0.05);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 40px rgba(33, 37, 41, 0.12);
+}
+
+.card-img-top-wrapper {
+  height: 200px;
+  overflow: hidden;
+  border-radius: 12px;
+  background: var(--color-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.card-img-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.card-img-top {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.card-img-top-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--color-secondary);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 /* Responsive adjustments */

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -31,23 +31,44 @@
   <div class="row">
     {% for product in page_obj %}
       <div class="col-md-4 mb-4">
-        <div class="card h-100">
-          {% if product.image %}
-            <a href="{% url 'product_detail' product.slug %}">
-              <img src="{{ product.image.url }}" class="card-img-top" alt="{{ product.name }}">
-            </a>
-          {% endif %}
-          <div class="card-body">
-            <h5 class="card-title">
+        <div class="card h-100 d-flex flex-column">
+          <div class="card-img-top-wrapper mb-3">
+            {% if product.image %}
+              <a href="{% url 'product_detail' product.slug %}" class="card-img-link">
+                <img
+                  src="{{ product.image.url }}"
+                  class="card-img-top"
+                  alt="{{ product.name }}"
+                  loading="lazy"
+                >
+              </a>
+            {% else %}
+              <span class="card-img-top-placeholder">Без зображення</span>
+            {% endif %}
+          </div>
+          <div class="card-body d-flex flex-column gap-2 p-0">
+            <h5 class="card-title mb-0">
               <a href="{% url 'product_detail' product.slug %}">{{ product.name }}</a>
             </h5>
-            <p class="card-text">{{ product.description }}</p>
+            <p class="card-text text-muted mb-0">{{ product.description|default_if_none:''|truncatechars:100 }}</p>
           </div>
-          <div class="card-footer d-flex justify-content-between align-items-center">
-            <strong>{{ product.price }} грн</strong>
-            <span class="{% if product.stock > 0 %}text-success{% else %}text-danger{% endif %}">
-              {% if product.stock > 0 %}в наявності{% else %}немає{% endif %}
-            </span>
+          <div class="card-footer bg-transparent border-0 pt-0 mt-auto">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <strong>{{ product.price }} грн</strong>
+              <span class="{% if product.stock > 0 %}text-success{% else %}text-danger{% endif %}">
+                {% if product.stock > 0 %}в наявності{% else %}немає{% endif %}
+              </span>
+            </div>
+            {% if product.stock > 0 %}
+              <a
+                href="{% url 'cart:add' product.slug %}?next={{ request.get_full_path|urlencode }}"
+                class="btn btn-outline-primary w-100"
+              >
+                Додати в кошик
+              </a>
+            {% else %}
+              <span class="btn btn-outline-secondary w-100 disabled" aria-disabled="true">Немає в наявності</span>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- shorten product previews in the product list, wrap images in a fixed-height container, and add an "Add to cart" button that links back to the listing when finished
- refresh the shared card styles with hover shadows, smooth transitions, and helpers for the new image placeholder container
- add a cart addition view/URL that creates or reuses the active cart for the session before redirecting

## Testing
- pip install -r biomarket/requirements.txt *(fails: proxy blocks package download)*

------
https://chatgpt.com/codex/tasks/task_e_68c913cb58b8832ca476a341d174a973