### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/biomarket/requirements.txt
+++ b/biomarket/requirements.txt
@@ -2,3 +2,5 @@ Django>=5.0,<5.2
 gunicorn>=21.2
 whitenoise>=6.6
 Pillow>=10.0
+
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- add python-dotenv to the deployment requirements so the package installs during deployment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c92058a49c832c8c6e208f9c7f9e9b