### PR TITLE
Configure Render build to collect static files

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: biomarket
     env: python
-    buildCommand: cd biomarket && pip install -r requirements.txt
+    buildCommand: cd biomarket && pip install -r requirements.txt && python manage.py collectstatic --noinput
     startCommand: cd biomarket && python manage.py migrate && gunicorn biomarket.wsgi
     envVars:
       - key: DJANGO_DB_PATH


### PR DESCRIPTION
## Summary
- append `python manage.py collectstatic --noinput` to the Render build command so static assets are gathered during deployment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9205ecc28832cb0e125eb7e14d01e