### PR TITLE
Enforce cart uniqueness constraints

### DIFF
--- a/biomarket/cart/migrations/0002_unique_constraints.py
+++ b/biomarket/cart/migrations/0002_unique_constraints.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cart", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="cartitem",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="cart",
+            constraint=models.UniqueConstraint(
+                fields=("user",),
+                name="unique_cart_user",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="cartitem",
+            constraint=models.UniqueConstraint(
+                fields=("cart", "product"),
+                name="unique_cartitem_cart_product",
+            ),
+        ),
+    ]

--- a/biomarket/cart/models.py
+++ b/biomarket/cart/models.py
@@ -14,6 +14,12 @@ class Cart(models.Model):
 
     class Meta:
         ordering = ("-created_at",)
+        constraints = (
+            models.UniqueConstraint(
+                fields=("user",),
+                name="unique_cart_user",
+            ),
+        )
 
     def __str__(self) -> str:
         if self.user:
@@ -28,8 +34,13 @@ class CartItem(models.Model):
     added_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        unique_together = ("cart", "product")
         ordering = ("-added_at",)
+        constraints = (
+            models.UniqueConstraint(
+                fields=("cart", "product"),
+                name="unique_cartitem_cart_product",
+            ),
+        )
 
     def __str__(self) -> str:
         return f"{self.quantity} x {self.product}"  # pragma: no cover - string repr only


### PR DESCRIPTION
## Summary
- add a unique constraint on `Cart.user` to enforce one cart per user
- convert `CartItem`'s `unique_together` into an explicit `UniqueConstraint`
- add a migration to drop the old unique together and apply the new constraints

## Testing
- python biomarket/manage.py makemigrations *(fails: ModuleNotFoundError: No module named 'django' because packages cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9206b7b64832ca3f7bab258dc9b1a