### PR TITLE
Add cart and account templates

### DIFF
--- a/biomarket/accounts/views.py
+++ b/biomarket/accounts/views.py
@@ -1,22 +1,54 @@
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.contrib.auth import get_user_model
 
 from .models import UserProfile
 
 
 def profile_overview(request: HttpRequest) -> HttpResponse:
-    """Display a minimal placeholder profile page for the current user."""
+    """Display a profile overview page for the current user."""
+
+    profile = None
+    meta_title = "Профіль гостя — Biomarket"
+    description = "Увійдіть до Biomarket, щоб переглянути персональний профіль та історію замовлень."
+    keywords = "Biomarket, профіль, обліковий запис"
+
     if request.user.is_authenticated:
         profile, _ = UserProfile.objects.get_or_create(user=request.user)
-        message = f"Profile for {profile.user.get_username()}"
-    else:
-        message = "Anonymous profile placeholder"
-    return HttpResponse(message, content_type="text/plain")
+        username = profile.user.get_username()
+        meta_title = f"Профіль {username} — Biomarket"
+        description = f"Персональна інформація та контактні дані користувача {username} в Biomarket."
+        keywords = f"Biomarket, профіль користувача, {username}"
+
+    context = {
+        "profile": profile,
+        "meta_title": meta_title,
+        "description": description,
+        "keywords": keywords,
+        "og_type": "profile",
+        "twitter_card": "summary",
+    }
+
+    return render(request, "accounts/overview.html", context)
 
 
 def profile_detail(request: HttpRequest, username: str) -> HttpResponse:
+    """Display a detailed public profile page for the selected user."""
+
     user_model = get_user_model()
     user = get_object_or_404(user_model, username=username)
     profile, _ = UserProfile.objects.get_or_create(user=user)
-    return HttpResponse(f"Profile page for {profile.user.get_username()}", content_type="text/plain")
+    is_owner = request.user.is_authenticated and request.user.pk == user.pk
+
+    context = {
+        "profile": profile,
+        "profile_user": user,
+        "is_owner": is_owner,
+        "meta_title": f"Профіль {user.get_username()} — Biomarket",
+        "description": f"Публічний профіль користувача {user.get_username()} на Biomarket.",
+        "keywords": f"Biomarket, профіль користувача, {user.get_username()}",
+        "og_type": "profile",
+        "twitter_card": "summary",
+    }
+
+    return render(request, "accounts/detail.html", context)

--- a/biomarket/templates/accounts/detail.html
+++ b/biomarket/templates/accounts/detail.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}{{ meta_title|default:"Профіль — Biomarket" }}{% endblock %}
+
+{% block content %}
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-8 col-xl-6">
+        <div class="card border-0 shadow-sm">
+          <div class="card-body p-4 p-md-5">
+            <div class="d-flex flex-column flex-sm-row justify-content-between align-items-sm-start gap-3 mb-4">
+              <div>
+                <h1 class="h3 mb-1">Профіль {{ profile_user.get_username }}</h1>
+                <p class="text-muted mb-0">На Biomarket з {{ profile_user.date_joined|date:"d.m.Y" }}</p>
+              </div>
+              {% if is_owner %}
+                <span class="badge bg-success align-self-sm-center">Це ви</span>
+              {% endif %}
+            </div>
+            <dl class="row gy-3 mb-4">
+              <dt class="col-sm-4 text-muted">Повне ім'я</dt>
+              <dd class="col-sm-8">{{ profile_user.get_full_name|default:profile_user.get_username }}</dd>
+              <dt class="col-sm-4 text-muted">Електронна пошта</dt>
+              <dd class="col-sm-8">{{ profile_user.email|default:"Не вказано" }}</dd>
+              <dt class="col-sm-4 text-muted">Телефон</dt>
+              <dd class="col-sm-8">{{ profile.phone|default:"Не вказано" }}</dd>
+              <dt class="col-sm-4 text-muted">Адреса</dt>
+              <dd class="col-sm-8">
+                {% if profile.address %}
+                  {{ profile.address|linebreaksbr }}
+                {% else %}
+                  Не вказано
+                {% endif %}
+              </dd>
+              <dt class="col-sm-4 text-muted">Профіль створено</dt>
+              <dd class="col-sm-8">{{ profile.created_at|date:"d.m.Y H:i" }}</dd>
+            </dl>
+            <div class="d-flex flex-wrap gap-2">
+              <a class="btn btn-outline-primary" href="{% url 'product_list' %}">Каталог товарів</a>
+              {% if is_owner %}
+                <a class="btn btn-primary" href="{% url 'accounts:overview' %}">Повернутися до мого профілю</a>
+              {% else %}
+                <a class="btn btn-primary" href="{% url 'accounts:overview' %}">Мій профіль</a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/biomarket/templates/accounts/overview.html
+++ b/biomarket/templates/accounts/overview.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}{{ meta_title|default:"Профіль — Biomarket" }}{% endblock %}
+
+{% block content %}
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-8 col-xl-6">
+        <div class="card border-0 shadow-sm">
+          <div class="card-body p-4 p-md-5">
+            <h1 class="h3 mb-4">Мій профіль</h1>
+            {% if profile %}
+              <p class="text-muted">Ви увійшли як <strong>{{ profile.user.get_username }}</strong>.</p>
+              <dl class="row gy-3 mb-0">
+                <dt class="col-sm-4 text-muted">Електронна пошта</dt>
+                <dd class="col-sm-8">{{ profile.user.email|default:"Не вказано" }}</dd>
+                <dt class="col-sm-4 text-muted">Телефон</dt>
+                <dd class="col-sm-8">{{ profile.phone|default:"Не вказано" }}</dd>
+                <dt class="col-sm-4 text-muted">Адреса</dt>
+                <dd class="col-sm-8">
+                  {% if profile.address %}
+                    {{ profile.address|linebreaksbr }}
+                  {% else %}
+                    Не вказано
+                  {% endif %}
+                </dd>
+                <dt class="col-sm-4 text-muted">Профіль створено</dt>
+                <dd class="col-sm-8">{{ profile.created_at|date:"d.m.Y H:i" }}</dd>
+              </dl>
+              <div class="d-flex flex-wrap gap-2 mt-4">
+                <a class="btn btn-primary" href="{% url 'accounts:detail' profile.user.username %}">Переглянути публічний профіль</a>
+                <a class="btn btn-outline-primary" href="{% url 'product_list' %}">До каталогу товарів</a>
+              </div>
+            {% else %}
+              <div class="text-center py-4">
+                <p class="text-muted mb-4">Щоб переглянути персональний профіль, увійдіть до свого облікового запису Biomarket.</p>
+                <a class="btn btn-primary" href="{% url 'home' %}">Повернутися на головну</a>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/biomarket/templates/cart/home.html
+++ b/biomarket/templates/cart/home.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% block title %}{{ meta_title|default:"Кошик — Biomarket" }}{% endblock %}
+
+{% block content %}
+  <div class="container py-5">
+    <div class="row">
+      <div class="col-12">
+        <h1 class="display-5 mb-3">Ваш кошик</h1>
+        <p class="text-muted mb-4">Перегляньте додані товари та перейдіть до оформлення замовлення.</p>
+      </div>
+    </div>
+    {% if cart_items %}
+      <div class="row g-4">
+        <div class="col-lg-8">
+          <div class="list-group shadow-sm">
+            {% for item in cart_items %}
+              <article class="list-group-item list-group-item-action py-4">
+                <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                  <div>
+                    <h2 class="h5 mb-1">
+                      <a class="text-decoration-none" href="{{ item.product.get_absolute_url }}">{{ item.product.name }}</a>
+                    </h2>
+                    {% if item.product.description %}
+                      <p class="mb-2 text-muted small">{{ item.product.description|truncatechars:120 }}</p>
+                    {% endif %}
+                    <div class="d-flex flex-wrap gap-3 small text-muted">
+                      <span>Кількість: <strong class="text-dark">{{ item.quantity }}</strong></span>
+                      <span>Ціна за одиницю: <strong class="text-dark">{{ item.product.price|floatformat:2 }} ₴</strong></span>
+                    </div>
+                  </div>
+                  <div class="text-md-end">
+                    <div class="fw-semibold fs-5">{{ item.line_total|floatformat:2 }} ₴</div>
+                    <div class="text-muted small">Разом</div>
+                  </div>
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <aside class="card border-0 shadow-sm">
+            <div class="card-body">
+              <h2 class="h5 mb-3">Підсумок замовлення</h2>
+              <dl class="row mb-0 small">
+                <dt class="col-6 text-muted">Товарів</dt>
+                <dd class="col-6 text-end text-dark">{{ cart_quantity }}</dd>
+                <dt class="col-6 text-muted">Сума</dt>
+                <dd class="col-6 text-end text-dark fw-semibold fs-5">{{ cart_total|floatformat:2 }} ₴</dd>
+              </dl>
+              <div class="d-grid gap-2 mt-4">
+                <button class="btn btn-primary" type="button" disabled>Оформити замовлення</button>
+                <a class="btn btn-outline-primary" href="{% url 'product_list' %}">Продовжити покупки</a>
+              </div>
+              <p class="mt-3 mb-0 small text-muted">Підтвердіть замовлення та заповніть дані доставки на наступному кроці.</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    {% else %}
+      <div class="row justify-content-center">
+        <div class="col-lg-6">
+          <div class="card border-0 shadow-sm text-center">
+            <div class="card-body py-5">
+              <h2 class="h4 mb-3">Ваш кошик порожній</h2>
+              <p class="text-muted mb-4">Додайте улюблені товари Biomarket до кошика, щоб оформити замовлення.</p>
+              <a class="btn btn-primary" href="{% url 'product_list' %}">Переглянути каталог</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- render the cart home view with cart metadata and totals for the template
- render account overview and detail views with profile context instead of plain text responses
- add Bootstrap-based templates for the cart, account overview, and account detail pages

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c9206fad38832c812d1905b739af8b