### PR TITLE
Enforce runtime environment variables for Django settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ python manage.py migrate
 python manage.py collectstatic
 ```
 
-3. Запустіть сервер розробника:
+3. Перед запуском налаштуйте змінні середовища (наприклад, у файлі `.env` в корені проєкту):
+
+```
+DJANGO_SECRET_KEY=your-secure-secret-key
+ALLOWED_HOSTS=127.0.0.1,localhost
+DEBUG=1
+```
+
+`DJANGO_SECRET_KEY` та `ALLOWED_HOSTS` обов'язково повинні бути визначені у робочому середовищі (напр., через Render, Docker або хмарну платформу).
+
+4. Запустіть сервер розробника:
 
 ```bash
 python manage.py runserver

--- a/biomarket/biomarket/settings.py
+++ b/biomarket/biomarket/settings.py
@@ -1,14 +1,21 @@
 from pathlib import Path
 import os
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")            # читаємо змінні з .env
 
-# Безпечний ключ з env (обов’язково визначити в .env)
-SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "django-insecure-change-me")
+# Безпечний ключ з env (обов’язково визначити через змінну оточення)
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    raise ImproperlyConfigured("DJANGO_SECRET_KEY environment variable is required")
 DEBUG = os.getenv("DEBUG", "0") == "1"
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
+allowed_hosts_env = os.getenv("ALLOWED_HOSTS")
+if allowed_hosts_env:
+    ALLOWED_HOSTS = [host.strip() for host in allowed_hosts_env.split(",") if host.strip()]
+else:
+    ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,10 @@ services:
     buildCommand: cd biomarket && pip install -r requirements.txt && python manage.py collectstatic --noinput
     startCommand: cd biomarket && python manage.py migrate && gunicorn biomarket.wsgi
     envVars:
+      - key: DJANGO_SECRET_KEY
+        sync: false   # задайте значення у налаштуваннях Render
+      - key: ALLOWED_HOSTS
+        sync: false   # напр., example.com або список через кому
       - key: DJANGO_DB_PATH
         value: /var/data/db.sqlite3
     disk:


### PR DESCRIPTION
## Summary
- raise an ImproperlyConfigured error when DJANGO_SECRET_KEY is missing
- require ALLOWED_HOSTS to be provided via environment configuration instead of defaulting to "*"
- document the required environment variables for local and Render deployments

## Testing
- DJANGO_SECRET_KEY=test-secret ALLOWED_HOSTS=localhost python manage.py check *(fails: django missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c1b4a24832ca6ea7da6f19a4e04