### PR TITLE
Update Render DB env var reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ DEBUG=1
 
 `DJANGO_SECRET_KEY` та `ALLOWED_HOSTS` обов'язково повинні бути визначені у робочому середовищі (напр., через Render, Docker або хмарну платформу).
 
+## Деплой на Render
+
+- Використайте `render.yaml`, щоб створити сервіс типу **Web Service**.
+- У налаштуваннях середовища задайте змінні:
+  - `DJANGO_SECRET_KEY` — секретний ключ Django.
+  - `ALLOWED_HOSTS` — дозволені домени, розділені комами.
+  - `DB_NAME` — шлях до файлу бази даних (за умовчанням `/var/data/db.sqlite3`).
+
+`DB_NAME` відповідає значенню, яке читає `biomarket/biomarket/settings.py` для параметра `DATABASES['default']['NAME']`.
+
 4. Запустіть сервер розробника:
 
 ```bash

--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
         sync: false   # задайте значення у налаштуваннях Render
       - key: ALLOWED_HOSTS
         sync: false   # напр., example.com або список через кому
-      - key: DJANGO_DB_PATH
+      - key: DB_NAME
         value: /var/data/db.sqlite3
     disk:
       name: data


### PR DESCRIPTION
## Summary
- rename the Render environment variable for the database from `DJANGO_DB_PATH` to `DB_NAME`
- add deployment notes documenting the new `DB_NAME` variable and its role in Django settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c94c2390a0832cb8b1ff04e09a3f39