### PR TITLE
Require POST for add to cart view

### DIFF
--- a/biomarket/cart/tests.py
+++ b/biomarket/cart/tests.py
@@ -44,3 +44,9 @@ class AddToCartViewTests(TestCase):
 
         self.assertEqual(cart.items.count(), 1)
         self.assertEqual(cart_item.quantity, 2)
+
+    def test_add_to_cart_rejects_get_requests(self):
+        response = self.client.get(reverse("cart:add", args=[self.product.slug]))
+
+        self.assertEqual(response.status_code, 405)
+        self.assertNotIn("cart_id", self.client.session)

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -60,12 +60,13 @@
               </span>
             </div>
             {% if product.stock > 0 %}
-              <a
-                href="{% url 'cart:add' product.slug %}?next={{ request.get_full_path|urlencode }}"
-                class="btn btn-outline-primary w-100"
-              >
-                Додати в кошик
-              </a>
+              <form action="{% url 'cart:add' product.slug %}" method="post" class="d-grid">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-outline-primary w-100">
+                  Додати в кошик
+                </button>
+              </form>
             {% else %}
               <span class="btn btn-outline-secondary w-100 disabled" aria-disabled="true">Немає в наявності</span>
             {% endif %}


### PR DESCRIPTION
## Summary
- require POST on the add_to_cart view and preserve next parameter handling
- update the product listing template to submit add-to-cart actions via a POST form with CSRF protection
- add a regression test ensuring GET requests to the add_to_cart endpoint return HTTP 405

## Testing
- python biomarket/manage.py test cart *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68c94c308b78832cb0878e303c2a5f9f