### PR TITLE
Ensure user profiles are created explicitly

### DIFF
--- a/biomarket/accounts/apps.py
+++ b/biomarket/accounts/apps.py
@@ -5,3 +5,11 @@ class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "accounts"
     verbose_name = "Accounts"
+
+    def ready(self) -> None:  # pragma: no cover - Django hook
+        """Load signal handlers when the app is ready."""
+
+        # Importing signals ensures they are registered once Django starts.
+        import accounts.signals  # noqa: F401
+
+        super().ready()

--- a/biomarket/accounts/signals.py
+++ b/biomarket/accounts/signals.py
@@ -1,0 +1,17 @@
+"""Signal handlers for the accounts application."""
+
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import UserProfile
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_user_profile(sender, instance, created, **kwargs):
+    """Ensure each user has an associated profile."""
+
+    if not created:
+        return
+
+    UserProfile.objects.get_or_create(user=instance)

--- a/biomarket/accounts/tests.py
+++ b/biomarket/accounts/tests.py
@@ -1,0 +1,23 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import UserProfile
+
+
+class ProfileDetailViewTests(TestCase):
+    def test_profile_detail_does_not_create_profile(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username="alice",
+            email="alice@example.com",
+            password="example-password",
+        )
+
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        initial_profile_count = UserProfile.objects.count()
+
+        response = self.client.get(reverse("accounts:detail", args=[user.username]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UserProfile.objects.count(), initial_profile_count)

--- a/biomarket/accounts/views.py
+++ b/biomarket/accounts/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.contrib.auth import get_user_model
 
@@ -14,7 +14,11 @@ def profile_overview(request: HttpRequest) -> HttpResponse:
     keywords = "Biomarket, профіль, обліковий запис"
 
     if request.user.is_authenticated:
-        profile, _ = UserProfile.objects.get_or_create(user=request.user)
+        try:
+            profile = UserProfile.objects.get(user=request.user)
+        except UserProfile.DoesNotExist as exc:
+            raise Http404("Profile not found") from exc
+
         username = profile.user.get_username()
         meta_title = f"Профіль {username} — Biomarket"
         description = f"Персональна інформація та контактні дані користувача {username} в Biomarket."
@@ -37,7 +41,10 @@ def profile_detail(request: HttpRequest, username: str) -> HttpResponse:
 
     user_model = get_user_model()
     user = get_object_or_404(user_model, username=username)
-    profile, _ = UserProfile.objects.get_or_create(user=user)
+    try:
+        profile = UserProfile.objects.get(user=user)
+    except UserProfile.DoesNotExist as exc:
+        raise Http404("Profile not found") from exc
     is_owner = request.user.is_authenticated and request.user.pk == user.pk
 
     context = {

--- a/biomarket/biomarket/settings.py
+++ b/biomarket/biomarket/settings.py
@@ -28,7 +28,7 @@ INSTALLED_APPS = [
     "django.contrib.humanize",  # корисні шаблонні фільтри
     "products",                 # каталог товарів
     "cart",                     # кошик (новий додаток)
-    "accounts",                 # реєстрація/профілі (новий додаток)
+    "accounts.apps.AccountsConfig",  # реєстрація/профілі (новий додаток)
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- raise a 404 when a user profile is missing instead of implicitly creating records in the account views
- create user profiles via a post-save signal that is loaded from the accounts app configuration and update settings to use it
- add a regression test confirming that the profile detail view does not create a new profile

## Testing
- python biomarket/manage.py test accounts *(fails: ModuleNotFoundError: No module named 'django' because dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c953566960832cba424402784797ef