### PR TITLE
Require POST for cart add view

### DIFF
--- a/biomarket/cart/tests.py
+++ b/biomarket/cart/tests.py
@@ -31,6 +31,20 @@ class AddToCartViewTests(TestCase):
         self.assertEqual(cart_item.quantity, 1)
         self.assertEqual(cart.items.count(), 1)
 
+    def test_add_to_cart_respects_next_parameter_from_post(self):
+        next_url = reverse("product_list")
+        response = self.client.post(
+            reverse("cart:add", args=[self.product.slug]),
+            data={"next": next_url},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, next_url)
+
+    def test_add_to_cart_rejects_get_requests(self):
+        response = self.client.get(reverse("cart:add", args=[self.product.slug]))
+        self.assertEqual(response.status_code, 405)
+
     def test_add_to_cart_increments_quantity_for_existing_item(self):
         first_response = self.client.post(reverse("cart:add", args=[self.product.slug]))
         self.assertEqual(first_response.status_code, 302)

--- a/biomarket/cart/views.py
+++ b/biomarket/cart/views.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.http import require_POST
 
 from products.models import Product
 
@@ -77,11 +78,12 @@ def _get_or_create_cart(request: HttpRequest) -> Cart:
     return cart
 
 
+@require_POST
 def add_to_cart(request: HttpRequest, slug: str) -> HttpResponse:
     """Add the selected product to the active cart and redirect back."""
 
     product = get_object_or_404(Product, slug=slug)
-    next_url = request.GET.get("next")
+    next_url = request.POST.get("next") or request.GET.get("next")
     next_url_is_safe = bool(
         next_url
         and url_has_allowed_host_and_scheme(

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -60,12 +60,17 @@
               </span>
             </div>
             {% if product.stock > 0 %}
-              <a
-                href="{% url 'cart:add' product.slug %}?next={{ request.get_full_path|urlencode }}"
-                class="btn btn-outline-primary w-100"
+              <form
+                method="post"
+                action="{% url 'cart:add' product.slug %}"
+                class="d-grid"
               >
-                Додати в кошик
-              </a>
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-outline-primary w-100">
+                  Додати в кошик
+                </button>
+              </form>
             {% else %}
               <span class="btn btn-outline-secondary w-100 disabled" aria-disabled="true">Немає в наявності</span>
             {% endif %}


### PR DESCRIPTION
## Summary
- require POST requests for the cart add view and continue supporting safe redirects
- update the product list template to submit add-to-cart actions as POST forms with CSRF protection
- extend cart view tests to cover POST redirects and the new method restriction

## Testing
- python biomarket/manage.py test cart *(fails: ModuleNotFoundError: No module named 'django')*
- pip install -r biomarket/requirements.txt *(fails: Could not find a version that satisfies the requirement Django<5.2,>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c9647f05c8832ca41657a2e9341421