### PR TITLE
Namespace product URLs

### DIFF
--- a/biomarket/products/models.py
+++ b/biomarket/products/models.py
@@ -51,4 +51,4 @@ class Product(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("product_detail", args=[self.slug])
+        return reverse("products:product_detail", args=[self.slug])

--- a/biomarket/products/tests.py
+++ b/biomarket/products/tests.py
@@ -91,7 +91,7 @@ class ProductListViewTests(TestCase):
                 stock=10,
             )
 
-        response = self.client.get(reverse("product_list"))
+        response = self.client.get(reverse("products:product_list"))
         self.assertEqual(response.status_code, 200)
 
         page_obj = response.context["page_obj"]
@@ -99,7 +99,7 @@ class ProductListViewTests(TestCase):
         self.assertEqual(page_obj.number, 1)
         self.assertEqual(len(response.context["products"]), 12)
 
-        second_page = self.client.get(reverse("product_list"), {"page": 2})
+        second_page = self.client.get(reverse("products:product_list"), {"page": 2})
         self.assertEqual(second_page.status_code, 200)
         second_page_obj = second_page.context["page_obj"]
         self.assertEqual(second_page_obj.number, 2)
@@ -125,7 +125,7 @@ class ProductListViewTests(TestCase):
             stock=20,
         )
 
-        response = self.client.get(reverse("product_list"), {"q": "honey"})
+        response = self.client.get(reverse("products:product_list"), {"q": "honey"})
         self.assertEqual(response.status_code, 200)
 
         products = list(response.context["products"])

--- a/biomarket/products/urls.py
+++ b/biomarket/products/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = "products"
+
 urlpatterns = [
     path('', views.product_list, name='product_list'),
     path('<slug:slug>/', views.product_detail, name='product_detail'),

--- a/biomarket/templates/accounts/detail.html
+++ b/biomarket/templates/accounts/detail.html
@@ -36,7 +36,7 @@
               <dd class="col-sm-8">{{ profile.created_at|date:"d.m.Y H:i" }}</dd>
             </dl>
             <div class="d-flex flex-wrap gap-2">
-              <a class="btn btn-outline-primary" href="{% url 'product_list' %}">Каталог товарів</a>
+              <a class="btn btn-outline-primary" href="{% url 'products:product_list' %}">Каталог товарів</a>
               {% if is_owner %}
                 <a class="btn btn-primary" href="{% url 'accounts:overview' %}">Повернутися до мого профілю</a>
               {% else %}

--- a/biomarket/templates/accounts/overview.html
+++ b/biomarket/templates/accounts/overview.html
@@ -29,7 +29,7 @@
               </dl>
               <div class="d-flex flex-wrap gap-2 mt-4">
                 <a class="btn btn-primary" href="{% url 'accounts:detail' profile.user.username %}">Переглянути публічний профіль</a>
-                <a class="btn btn-outline-primary" href="{% url 'product_list' %}">До каталогу товарів</a>
+                <a class="btn btn-outline-primary" href="{% url 'products:product_list' %}">До каталогу товарів</a>
               </div>
             {% else %}
               <div class="text-center py-4">

--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -48,7 +48,7 @@
                 <a class="nav-link {% if request.resolver_match.url_name == 'home' %}active{% endif %}" href="{% url 'home' %}">Головна</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.url_name == 'product_list' %}active{% endif %}" href="{% url 'product_list' %}">Каталог</a>
+                <a class="nav-link {% if request.resolver_match.url_name == 'product_list' %}active{% endif %}" href="{% url 'products:product_list' %}">Каталог</a>
               </li>
               <li class="nav-item">
                 <a class="nav-link {% if request.resolver_match.url_name == 'about' %}active{% endif %}" href="{% url 'about' %}">Про нас</a>
@@ -57,7 +57,7 @@
                 <a class="nav-link {% if request.resolver_match.url_name == 'contacts' %}active{% endif %}" href="{% url 'contacts' %}">Контакти</a>
               </li>
             </ul>
-            <form class="d-flex ms-lg-auto mt-3 mt-lg-0" role="search" action="{% url 'product_list' %}" method="get">
+            <form class="d-flex ms-lg-auto mt-3 mt-lg-0" role="search" action="{% url 'products:product_list' %}" method="get">
               <label class="visually-hidden" for="navbar-search">Пошук товарів</label>
               <input
                 class="form-control me-2"

--- a/biomarket/templates/cart/home.html
+++ b/biomarket/templates/cart/home.html
@@ -50,7 +50,7 @@
               </dl>
               <div class="d-grid gap-2 mt-4">
                 <button class="btn btn-primary" type="button" disabled>Оформити замовлення</button>
-                <a class="btn btn-outline-primary" href="{% url 'product_list' %}">Продовжити покупки</a>
+                <a class="btn btn-outline-primary" href="{% url 'products:product_list' %}">Продовжити покупки</a>
               </div>
               <p class="mt-3 mb-0 small text-muted">Підтвердіть замовлення та заповніть дані доставки на наступному кроці.</p>
             </div>
@@ -64,7 +64,7 @@
             <div class="card-body py-5">
               <h2 class="h4 mb-3">Ваш кошик порожній</h2>
               <p class="text-muted mb-4">Додайте улюблені товари Biomarket до кошика, щоб оформити замовлення.</p>
-              <a class="btn btn-primary" href="{% url 'product_list' %}">Переглянути каталог</a>
+              <a class="btn btn-primary" href="{% url 'products:product_list' %}">Переглянути каталог</a>
             </div>
           </div>
         </div>

--- a/biomarket/templates/products/list.html
+++ b/biomarket/templates/products/list.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <h1>Список товарів</h1>
-  <form action="{% url 'product_list' %}" method="get" class="row g-2 align-items-end mb-4">
+  <form action="{% url 'products:product_list' %}" method="get" class="row g-2 align-items-end mb-4">
     <div class="col-md-6">
       <label class="form-label" for="product-search">Пошук</label>
       <input
@@ -34,7 +34,7 @@
         <div class="card h-100 d-flex flex-column">
           <div class="card-img-top-wrapper mb-3">
             {% if product.image %}
-              <a href="{% url 'product_detail' product.slug %}" class="card-img-link">
+              <a href="{% url 'products:product_detail' product.slug %}" class="card-img-link">
                 <img
                   src="{{ product.image.url }}"
                   class="card-img-top"
@@ -48,7 +48,7 @@
           </div>
           <div class="card-body d-flex flex-column gap-2 p-0">
             <h5 class="card-title mb-0">
-              <a href="{% url 'product_detail' product.slug %}">{{ product.name }}</a>
+              <a href="{% url 'products:product_detail' product.slug %}">{{ product.name }}</a>
             </h5>
             <p class="card-text text-muted mb-0">{{ product.description|default_if_none:''|truncatechars:100 }}</p>
           </div>


### PR DESCRIPTION
## Summary
- namespace the product URLconf so reverse lookups can use the `products` namespace
- update product URL references across models, templates, and tests to use `products:product_list` and `products:product_detail`

## Testing
- python biomarket/manage.py test products *(fails: missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9648180f0832c891bb9854edc9bbf