### PR TITLE
Ensure profile overview creates missing profiles

### DIFF
--- a/biomarket/accounts/tests.py
+++ b/biomarket/accounts/tests.py
@@ -21,3 +21,22 @@ class ProfileDetailViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(UserProfile.objects.count(), initial_profile_count)
+
+
+class ProfileOverviewViewTests(TestCase):
+    def test_profile_overview_creates_missing_profile(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username="bob",
+            email="bob@example.com",
+            password="example-password",
+        )
+
+        UserProfile.objects.filter(user=user).delete()
+        self.assertFalse(UserProfile.objects.filter(user=user).exists())
+
+        self.client.force_login(user)
+        response = self.client.get(reverse("accounts:overview"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())

--- a/biomarket/accounts/views.py
+++ b/biomarket/accounts/views.py
@@ -14,10 +14,7 @@ def profile_overview(request: HttpRequest) -> HttpResponse:
     keywords = "Biomarket, профіль, обліковий запис"
 
     if request.user.is_authenticated:
-        try:
-            profile = UserProfile.objects.get(user=request.user)
-        except UserProfile.DoesNotExist as exc:
-            raise Http404("Profile not found") from exc
+        profile, _created = UserProfile.objects.get_or_create(user=request.user)
 
         username = profile.user.get_username()
         meta_title = f"Профіль {username} — Biomarket"


### PR DESCRIPTION
## Summary
- use `get_or_create` in the profile overview view so missing profiles are created automatically
- add a regression test that verifies the overview view creates a profile when it is missing

## Testing
- python manage.py test accounts *(fails: ModuleNotFoundError: No module named 'django' due to unavailable dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96487149c832cb6f959cac539e8ce