### PR TITLE
Add namespace to product URLs

### DIFF
--- a/biomarket/biomarket/urls.py
+++ b/biomarket/biomarket/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
         ),
         name="contacts",
     ),
-    path("products/", include("products.urls")),
+    path("products/", include("products.urls", namespace="products")),
     path("cart/", include("cart.urls")),
     path("accounts/", include("accounts.urls")),
     path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="sitemap"),

--- a/biomarket/cart/tests.py
+++ b/biomarket/cart/tests.py
@@ -32,7 +32,7 @@ class AddToCartViewTests(TestCase):
         self.assertEqual(cart.items.count(), 1)
 
     def test_add_to_cart_respects_next_parameter_from_post(self):
-        next_url = reverse("product_list")
+        next_url = reverse("products:product_list")
         response = self.client.post(
             reverse("cart:add", args=[self.product.slug]),
             data={"next": next_url},

--- a/biomarket/templates/base.html
+++ b/biomarket/templates/base.html
@@ -48,7 +48,7 @@
                 <a class="nav-link {% if request.resolver_match.url_name == 'home' %}active{% endif %}" href="{% url 'home' %}">Головна</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.url_name == 'product_list' %}active{% endif %}" href="{% url 'products:product_list' %}">Каталог</a>
+                <a class="nav-link {% if request.resolver_match.view_name == 'products:product_list' %}active{% endif %}" href="{% url 'products:product_list' %}">Каталог</a>
               </li>
               <li class="nav-item">
                 <a class="nav-link {% if request.resolver_match.url_name == 'about' %}active{% endif %}" href="{% url 'about' %}">Про нас</a>


### PR DESCRIPTION
## Summary
- add the products URL namespace to the project-level include
- update the cart tests and base template to reference the namespaced product list URL

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c969ccd38c832c962446eea8828d12