### PR TITLE
Update profile detail route to include user prefix

### DIFF
--- a/biomarket/accounts/tests.py
+++ b/biomarket/accounts/tests.py
@@ -22,6 +22,23 @@ class ProfileDetailViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(UserProfile.objects.count(), initial_profile_count)
 
+    def test_profile_detail_old_path_redirects(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username="carol",
+            email="carol@example.com",
+            password="example-password",
+        )
+
+        response = self.client.get(f"/accounts/{user.username}/")
+
+        self.assertRedirects(
+            response,
+            reverse("accounts:detail", args=[user.username]),
+            status_code=301,
+            target_status_code=200,
+        )
+
 
 class ProfileOverviewViewTests(TestCase):
     def test_profile_overview_creates_missing_profile(self):

--- a/biomarket/accounts/urls.py
+++ b/biomarket/accounts/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from . import views
 
@@ -6,5 +7,9 @@ app_name = "accounts"
 
 urlpatterns = [
     path("", views.profile_overview, name="overview"),
-    path("<str:username>/", views.profile_detail, name="detail"),
+    path("user/<str:username>/", views.profile_detail, name="detail"),
+    path(
+        "<str:username>/",
+        RedirectView.as_view(pattern_name="accounts:detail", permanent=True),
+    ),
 ]


### PR DESCRIPTION
## Summary
- prefix the public profile detail route with `user/` and keep a permanent redirect from the legacy path
- add a regression test to cover the legacy profile URL redirect

## Testing
- python manage.py test accounts *(fails: ModuleNotFoundError: No module named 'django'; dependencies unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c969d43eb0832ca90a5225a182a12c