### PR TITLE
Add namespaces for cart and accounts URLs

### DIFF
--- a/biomarket/accounts/tests.py
+++ b/biomarket/accounts/tests.py
@@ -30,7 +30,9 @@ class ProfileDetailViewTests(TestCase):
             password="example-password",
         )
 
-        response = self.client.get(f"/accounts/{user.username}/")
+        response = self.client.get(
+            reverse("accounts:legacy_detail", args=[user.username])
+        )
 
         self.assertRedirects(
             response,

--- a/biomarket/accounts/urls.py
+++ b/biomarket/accounts/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path(
         "<str:username>/",
         RedirectView.as_view(pattern_name="accounts:detail", permanent=True),
+        name="legacy_detail",
     ),
 ]

--- a/biomarket/biomarket/urls.py
+++ b/biomarket/biomarket/urls.py
@@ -53,7 +53,7 @@ urlpatterns = [
         name="contacts",
     ),
     path("products/", include("products.urls", namespace="products")),
-    path("cart/", include("cart.urls")),
-    path("accounts/", include("accounts.urls")),
+    path("cart/", include("cart.urls", namespace="cart")),
+    path("accounts/", include("accounts.urls", namespace="accounts")),
     path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="sitemap"),
 ]


### PR DESCRIPTION
## Summary
- include the cart and accounts URLs with explicit namespaces from the project router
- name the legacy accounts redirect route so tests can reverse it via the accounts namespace
- update the accounts redirect test to resolve the legacy URL through the namespace

## Testing
- ⚠️ `pip install -r biomarket/requirements.txt` (fails: ProxyError prevented downloading Django)
- ⚠️ `python biomarket/manage.py test` (fails: Django not installed due to previous step)


------
https://chatgpt.com/codex/tasks/task_e_68c96dff6ab8832c9b005b8b7d382f62