### PR TITLE
Support absolute next URLs for cart redirects

### DIFF
--- a/biomarket/cart/tests.py
+++ b/biomarket/cart/tests.py
@@ -41,6 +41,18 @@ class AddToCartViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, next_url)
 
+    def test_add_to_cart_allows_absolute_next_url_for_current_host(self):
+        next_path = reverse("products:product_list")
+        next_url = f"http://testserver{next_path}"
+
+        response = self.client.post(
+            reverse("cart:add", args=[self.product.slug]),
+            data={"next": next_url},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, next_url)
+
     def test_add_to_cart_rejects_get_requests(self):
         response = self.client.get(reverse("cart:add", args=[self.product.slug]))
         self.assertEqual(response.status_code, 405)

--- a/biomarket/cart/views.py
+++ b/biomarket/cart/views.py
@@ -101,7 +101,7 @@ def add_to_cart(request: HttpRequest, slug: str) -> HttpResponse:
         next_url
         and url_has_allowed_host_and_scheme(
             next_url,
-            allowed_hosts=settings.ALLOWED_HOSTS,
+            allowed_hosts=settings.ALLOWED_HOSTS or {request.get_host()},
         )
     )
 


### PR DESCRIPTION
## Summary
- allow the add_to_cart view to treat current-host absolute URLs as safe fallbacks when ALLOWED_HOSTS is empty
- extend the cart view test suite with coverage for absolute next redirects on the current host

## Testing
- `DJANGO_SECRET_KEY=test-secret python biomarket/manage.py test cart` *(fails: ModuleNotFoundError: No module named 'django'; dependencies unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e005674832c9d198426af5b7385