### PR TITLE
Add i18n and static context processors to templates

### DIFF
--- a/biomarket/biomarket/settings.py
+++ b/biomarket/biomarket/settings.py
@@ -54,6 +54,8 @@ TEMPLATES = [
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.static",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ],


### PR DESCRIPTION
## Summary
- add the Django i18n and static context processors so the LANGUAGE_CODE and STATIC_URL variables are available in templates

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: ModuleNotFoundError: No module named 'django' because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e01361c832cb01a77f9cd030406